### PR TITLE
Treebeard Feedback

### DIFF
--- a/.github/workflows/tb.yml
+++ b/.github/workflows/tb.yml
@@ -1,0 +1,37 @@
+name: Treebeard
+
+on: [pull_request, push]
+
+jobs:
+  run_treebeard_action:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        notebook:
+          - 'docs/*.ipynb'
+          - 'docs/tutorials/*.ipynb'
+          - 'docs/tutorials/educators/*.ipynb'
+          - 'cirq/**/*.ipynb'
+    name: Test NBs
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            papermill
+            jupyter
+            seaborn
+      - uses: treebeardtech/treebeard@master
+        with:
+          use-docker: false
+          notebooks: |
+            ${{ matrix.notebook }}
+          ignore: |
+            **/google/*.ipynb
+            **/pasqal/*.ipynb
+            **/aqt/*.ipynb
+            examples/advanced/*.ipynb
+            examples/*fidelity*


### PR DESCRIPTION
Hey @balopat,

No pressure to merge but wanted to get some more feedback on nb testing as you all have done such a great job with devops on Cirq.

Some changes since you tried tb:
1. Action inputs for `notebooks` and `ignore` fields accept newline delimited pattern lists (see [run](https://github.com/alex-treebeard/Cirq/actions/runs/366541504/workflow))
2. Each notebook is ran in it's own venv inheriting from system site packages 
3. I've cut the runtime down to 6mins using a pattern I stole from another [tb user](https://github.com/LabForComputationalVision/plenoptic)

I'm looking at integrating with pytest also to take advantage of `xdist`. Feel free to watch/share thoughts on https://github.com/treebeardtech/treebeard/issues/51

Based on your experience setting up workflows like this, are there other features you've been looking for in this problem area?